### PR TITLE
refactor(05-09): unify MMA tile to (2,4,1)x(1,1,2) and tighten copy ops

### DIFF
--- a/06-block-copy/cutedsl_block_copy.py
+++ b/06-block-copy/cutedsl_block_copy.py
@@ -210,28 +210,36 @@ def block_copy_gemm(
     sO_layout = cute.tile_to_shape(atom_O, (M, N, 1), order=(0, 1, 2))
 
     # ----- G2S (gmem -> smem) tiled copies using cp.async -----
-    # 128-bit-per-thread cp.async: 8 bf16 = 4 fp32 = 16 bytes.
+    # 128-bit-per-thread cp.async: 16 bytes / sizeof(elt) elements per copy.
     g2s_op = cute.nvgpu.cpasync.CopyG2SOp(
         cache_mode=cute.nvgpu.cpasync.LoadCacheMode.GLOBAL,
     )
 
-    # For A (M=128, K=64) and B (N=128, K=64), each row is 64 bf16 = 128 B,
-    # so a thread's 16-byte cp.async loads 8 bf16 along K. With 256 threads,
-    # we lay them out as 32 (M rows) x 8 (K chunks) per iteration.
-    tlA_thr = cute.make_layout((32, 8), stride=(8, 1))
-    tlA_val = cute.make_layout((1, 8))
+    # AB copy is along (M/N, K). Threads packed contiguously along K, each
+    # thread emits 16 / sizeof(elt) elements in a 128-bit cp.async. Mirrors
+    # block_copy.cu's TiledCopyA_G2S / TiledCopyB_G2S derived from
+    # kBlockK_Copy = min(64, kBlockK) / (16 / sizeof(elt)).
+    elt_bytes_ab = mA.element_type.width // 8
+    block_k_copy = min(64, K) // (16 // elt_bytes_ab)
+    tlAB_thr = cute.make_layout(
+        (NUM_THREADS // block_k_copy, block_k_copy),
+        stride=(block_k_copy, 1),
+    )
+    tlAB_val = cute.make_layout((1, 16 // elt_bytes_ab))
     g2s_atom_a = cute.make_copy_atom(g2s_op, mA.element_type, num_bits_per_copy=128)
-    g2s_tiled_copy_a = cute.make_tiled_copy_tv(g2s_atom_a, tlA_thr, tlA_val)
-
-    tlB_thr = cute.make_layout((32, 8), stride=(8, 1))
-    tlB_val = cute.make_layout((1, 8))
     g2s_atom_b = cute.make_copy_atom(g2s_op, mB.element_type, num_bits_per_copy=128)
-    g2s_tiled_copy_b = cute.make_tiled_copy_tv(g2s_atom_b, tlB_thr, tlB_val)
+    g2s_tiled_copy_a = cute.make_tiled_copy_tv(g2s_atom_a, tlAB_thr, tlAB_val)
+    g2s_tiled_copy_b = cute.make_tiled_copy_tv(g2s_atom_b, tlAB_thr, tlAB_val)
 
-    # For C (M=128, N=128) fp32: each row is 128 fp32 = 512 B, so a
-    # thread's 16-byte cp.async loads 4 fp32 along N. Use 32 (M) x 8 (N).
-    tlC_thr = cute.make_layout((32, 8), stride=(8, 1))
-    tlC_val = cute.make_layout((1, 4))
+    # C copy is along (M, N). Mirrors block_copy.cu's TiledCopyC_G2S derived
+    # from kBlockN_Copy = min(64, kBlockN) / (16 / sizeof(elt)).
+    elt_bytes_c = mC.element_type.width // 8
+    block_n_copy = min(64, N) // (16 // elt_bytes_c)
+    tlC_thr = cute.make_layout(
+        (NUM_THREADS // block_n_copy, block_n_copy),
+        stride=(block_n_copy, 1),
+    )
+    tlC_val = cute.make_layout((1, 16 // elt_bytes_c))
     g2s_atom_c = cute.make_copy_atom(g2s_op, mC.element_type, num_bits_per_copy=128)
     g2s_tiled_copy_c = cute.make_tiled_copy_tv(g2s_atom_c, tlC_thr, tlC_val)
 

--- a/07-swizzling/cutedsl_swizzling.py
+++ b/07-swizzling/cutedsl_swizzling.py
@@ -47,14 +47,14 @@ N = 128
 K = 64
 
 MMA_INST_MNK = (16, 8, 16)
-ATOM_LAYOUT_MNK = (2, 2, 1)
-VAL_EXPAND_MNK = (1, 2, 2)
+ATOM_LAYOUT_MNK = (2, 4, 1)
+VAL_EXPAND_MNK = (1, 1, 2)
 MMA_TILE_MNK = (
     ATOM_LAYOUT_MNK[0] * VAL_EXPAND_MNK[0] * MMA_INST_MNK[0],  # 32
     ATOM_LAYOUT_MNK[1] * VAL_EXPAND_MNK[1] * MMA_INST_MNK[1],  # 32
     ATOM_LAYOUT_MNK[2] * VAL_EXPAND_MNK[2] * MMA_INST_MNK[2],  # 32
 )
-NUM_THREADS = ATOM_LAYOUT_MNK[0] * ATOM_LAYOUT_MNK[1] * ATOM_LAYOUT_MNK[2] * 32  # 128
+NUM_THREADS = ATOM_LAYOUT_MNK[0] * ATOM_LAYOUT_MNK[1] * ATOM_LAYOUT_MNK[2] * 32  # 256
 
 
 # -----------------------------------------------------------------------------
@@ -79,7 +79,7 @@ def swizzling_kernel(
     s2g_tiled_copy_o: cute.TiledCopy,
     sA_layout: cute.ComposedLayout,
     sB_layout: cute.ComposedLayout,
-    sC_layout: cute.Layout,
+    sC_layout: cute.ComposedLayout,
     sO_layout: cute.ComposedLayout,
     acc_dtype: cutlass.Constexpr,
     out_dtype: cutlass.Constexpr,
@@ -103,22 +103,20 @@ def swizzling_kernel(
 
     # ----- Phase 1: gmem -> smem via cp.async -----
     thr_g2s_a = g2s_tiled_copy_a.get_slice(tid)
-    cute.copy(
-        g2s_tiled_copy_a,
-        thr_g2s_a.partition_S(gA),
-        thr_g2s_a.partition_D(sA),
-    )
+    tAgA_g2s = thr_g2s_a.partition_S(gA)
+    tAsA_g2s = thr_g2s_a.partition_D(sA)
+    cute.copy(g2s_tiled_copy_a, tAgA_g2s, tAsA_g2s)
 
     thr_g2s_b = g2s_tiled_copy_b.get_slice(tid)
-    cute.copy(
-        g2s_tiled_copy_b,
-        thr_g2s_b.partition_S(gB),
-        thr_g2s_b.partition_D(sB),
-    )
+    tBgB_g2s = thr_g2s_b.partition_S(gB)
+    tBsB_g2s = thr_g2s_b.partition_D(sB)
+    cute.copy(g2s_tiled_copy_b, tBgB_g2s, tBsB_g2s)
 
     if cutlass.const_expr(not is_gemm):
         thr_g2s_c = g2s_tiled_copy_c.get_slice(tid)
-        cute.copy(g2s_tiled_copy_c, thr_g2s_c.partition_S(gC), thr_g2s_c.partition_D(sC))
+        tCgC_g2s = thr_g2s_c.partition_S(gC)
+        tCsC_g2s = thr_g2s_c.partition_D(sC)
+        cute.copy(g2s_tiled_copy_c, tCgC_g2s, tCsC_g2s)
 
     cute.arch.cp_async_commit_group()
     cute.arch.cp_async_wait_group(0)
@@ -132,18 +130,14 @@ def swizzling_kernel(
 
     # ----- Phase 2: smem -> rmem via ldmatrix-backed TiledCopies -----
     thr_s2r_a = s2r_tiled_copy_a.get_slice(tid)
-    cute.copy(
-        s2r_tiled_copy_a,
-        thr_s2r_a.partition_S(sA),
-        thr_s2r_a.retile(tCrA),
-    )
+    tAsA_s2r = thr_s2r_a.partition_S(sA)
+    tArA_s2r = thr_s2r_a.retile(tCrA)
+    cute.copy(s2r_tiled_copy_a, tAsA_s2r, tArA_s2r)
 
     thr_s2r_b = s2r_tiled_copy_b.get_slice(tid)
-    cute.copy(
-        s2r_tiled_copy_b,
-        thr_s2r_b.partition_S(sB),
-        thr_s2r_b.retile(tCrB),
-    )
+    tBsB_s2r = thr_s2r_b.partition_S(sB)
+    tBrB_s2r = thr_s2r_b.retile(tCrB)
+    cute.copy(s2r_tiled_copy_b, tBsB_s2r, tBrB_s2r)
 
     if cutlass.const_expr(is_gemm):
         tCrC.fill(0.0)
@@ -156,11 +150,9 @@ def swizzling_kernel(
         # step. When acc_dtype == mC.element_type this is a no-op cast.
         thr_s2r_c = s2r_tiled_copy_c.get_slice(tid)
         tCrC_pre = cute.make_fragment_like(tCrC, mC.element_type)
-        cute.copy(
-            s2r_tiled_copy_c,
-            thr_s2r_c.partition_S(sC),
-            thr_s2r_c.retile(tCrC_pre),
-        )
+        tCsC_s2r = thr_s2r_c.partition_S(sC)
+        tCrC_s2r = thr_s2r_c.retile(tCrC_pre)
+        cute.copy(s2r_tiled_copy_c, tCsC_s2r, tCrC_s2r)
         tCrC.store(tCrC_pre.load().to(acc_dtype))
 
     # ----- Phase 3: compute -----
@@ -226,9 +218,14 @@ def swizzling_gemm(
     )
     sA_layout = cute.tile_to_shape(atom_AB, (M, K), order=(0, 1))
     sB_layout = cute.tile_to_shape(atom_AB, (N, K), order=(0, 1))
-    # The C preload buffer doesn't need swizzling for our flow; use a plain
-    # row-major layout.
-    sC_layout = cute.make_layout((M, N), stride=(N, 1))
+    # sC mirrors swizzling.cu's SmemLayoutC: Swizzle<3,3,3> o (8 x min(64, N)).
+    inner_C = min(64, N)
+    atom_C = cute.make_composed_layout(
+        swz,
+        0,
+        cute.make_layout((8, inner_C), stride=(inner_C, 1)),
+    )
+    sC_layout = cute.tile_to_shape(atom_C, (M, N), order=(0, 1))
     # sO mirrors swizzling.cu's SmemLayoutO: Swizzle<3,3,3> o (8 x min(64, BLK_N)).
     inner_O = min(64, N)
     atom_O = cute.make_composed_layout(
@@ -268,23 +265,37 @@ def swizzling_gemm(
     g2s_tiled_copy_c = cute.make_tiled_copy_tv(g2s_atom_c, tlC_thr, tlC_val)
 
     # ----- S2R tiled copies (ldmatrix for the 16-bit operands) -----
-    ldm_op = cute.nvgpu.warp.LdMatrix8x8x16bOp(False, 4)
-    s2r_atom_a = cute.make_copy_atom(ldm_op, mA.element_type)
-    s2r_atom_b = cute.make_copy_atom(ldm_op, mB.element_type)
+    # A/B own 4 32-bit packets per thread (VAL_EXPAND_K=2), so the x4
+    # ldmatrix variant fits exactly. C has no K val-expand, so each thread
+    # only owns 2 32-bit packets — use the x2 ldmatrix variant for the C
+    # s2r, mirroring swizzling.cu's Copy_S2R_op_C = SM75_U32x2_LDSM_N.
+    ldm_op_ab = cute.nvgpu.warp.LdMatrix8x8x16bOp(False, 4)
+    ldm_op_c = cute.nvgpu.warp.LdMatrix8x8x16bOp(False, 2)
+    s2r_atom_a = cute.make_copy_atom(ldm_op_ab, mA.element_type)
+    s2r_atom_b = cute.make_copy_atom(ldm_op_ab, mB.element_type)
     s2r_tiled_copy_a = cute.make_tiled_copy_A(s2r_atom_a, tm)
     s2r_tiled_copy_b = cute.make_tiled_copy_B(s2r_atom_b, tm)
     # C s2r: use ldmatrix if C is 16-bit, else universal copy (e.g. fp32).
     universal = cute.nvgpu.CopyUniversalOp()
     if cutlass.const_expr(mC.element_type.width == 16):
-        s2r_atom_c = cute.make_copy_atom(ldm_op, mC.element_type)
+        s2r_atom_c = cute.make_copy_atom(ldm_op_c, mC.element_type)
     else:
         s2r_atom_c = cute.make_copy_atom(universal, mC.element_type)
     s2r_tiled_copy_c = cute.make_tiled_copy_C(s2r_atom_c, tm)
 
     # ----- R2S + S2G copies for the smem-staged epilogue -----
-    # R2S: MMA-derived TiledCopy so each thread's accumulator fragment
-    # lands at its natural smem position under the swizzled sO layout.
-    r2s_atom_o = cute.make_copy_atom(universal, mO.element_type)
+    # R2S: MMA-derived TiledCopy so each thread's accumulator fragment lands
+    # at its natural smem position under the swizzled sO layout. Pick the op
+    # the same way swizzling.cu does: SM90+ with a 16-bit output uses
+    # ``stmatrix`` (x2 because the C/O fragment has no K val-expand and so
+    # owns 2 32-bit packets per thread); otherwise fall back to a universal
+    # STS lowering.
+    sm_major, _ = torch.cuda.get_device_capability()
+    if cutlass.const_expr(sm_major >= 9 and mO.element_type.width == 16):
+        stm_op = cute.nvgpu.warp.StMatrix8x8x16bOp(False, 2)
+        r2s_atom_o = cute.make_copy_atom(stm_op, mO.element_type)
+    else:
+        r2s_atom_o = cute.make_copy_atom(universal, mO.element_type)
     r2s_tiled_copy_o = cute.make_tiled_copy_C(r2s_atom_o, tm)
 
     # S2G: explicit TV layout — threads packed contiguously along N,

--- a/07-swizzling/swizzling.cu
+++ b/07-swizzling/swizzling.cu
@@ -246,11 +246,11 @@ struct KernelSpec {
   using MMA_shape = typename MMA_traits::Shape_MNK;
 
   static constexpr int kMmaThrExpandM = 2;
-  static constexpr int kMmaThrExpandN = 2;
+  static constexpr int kMmaThrExpandN = 4;
   static constexpr int kMmaThrExpandK = 1;
 
   static constexpr int kMmaValExpandM = 1;
-  static constexpr int kMmaValExpandN = 2;
+  static constexpr int kMmaValExpandN = 1;
   static constexpr int kMmaValExpandK = 2;
 
   static constexpr int kMmaTileM = kMmaThrExpandM * kMmaValExpandM * get<0>(MMA_shape{});
@@ -267,7 +267,11 @@ struct KernelSpec {
   // Note: ldmatrix only support 16-bit data type (or below)
   using Copy_S2R_op_A = std::conditional_t<sizeof(ComputeTypeA) == 2, SM75_U32x4_LDSM_N, AutoVectorizingCopy>;
   using Copy_S2R_op_B = std::conditional_t<sizeof(ComputeTypeB) == 2, SM75_U32x4_LDSM_N, AutoVectorizingCopy>;
-  using Copy_S2R_op_C = std::conditional_t<sizeof(ComputeTypeC) == 2, SM75_U32x4_LDSM_N, AutoVectorizingCopy>;
+  // The C / O accumulator fragment has no K val-expand, so each thread only
+  // owns half the 32-bit packets of an A/B fragment. Use the x2 LDSM/STSM
+  // variant for C-side copies; A/B keep x4 because VAL_EXPAND_K=2 gives them
+  // enough vals/thread.
+  using Copy_S2R_op_C = std::conditional_t<sizeof(ComputeTypeC) == 2, SM75_U32x2_LDSM_N, AutoVectorizingCopy>;
 
   using CopyA_G2S_atom = Copy_Atom<Copy_G2S_op, ComputeTypeA>;
   using CopyB_G2S_atom = Copy_Atom<Copy_G2S_op, ComputeTypeB>;
@@ -278,7 +282,9 @@ struct KernelSpec {
   using CopyC_S2R_atom = Copy_Atom<Copy_S2R_op_C, ComputeTypeC>;
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-  using Copy_R2S_op = SM90_U32x4_STSM_N;
+  // R2S writes a C-shaped fragment, so match the C-side x2 variant chosen
+  // above. SM90_U32x4_STSM_N would static_assert on too-few vals/thread.
+  using Copy_R2S_op = SM90_U32x2_STSM_N;
 #else
   using Copy_R2S_op = AutoVectorizingCopy;
 #endif

--- a/08-dynamic-mma/cutedsl_dynamic_mma.py
+++ b/08-dynamic-mma/cutedsl_dynamic_mma.py
@@ -44,10 +44,10 @@ BLK_K = 64
 
 MMA_INST_MNK = (16, 8, 16)
 ATOM_LAYOUT_MNK = (2, 4, 1)
-VAL_EXPAND_MNK = (1, 2, 2)
+VAL_EXPAND_MNK = (1, 1, 2)
 MMA_TILE_MNK = (
     ATOM_LAYOUT_MNK[0] * VAL_EXPAND_MNK[0] * MMA_INST_MNK[0],  # 32
-    ATOM_LAYOUT_MNK[1] * VAL_EXPAND_MNK[1] * MMA_INST_MNK[1],  # 64
+    ATOM_LAYOUT_MNK[1] * VAL_EXPAND_MNK[1] * MMA_INST_MNK[1],  # 32
     ATOM_LAYOUT_MNK[2] * VAL_EXPAND_MNK[2] * MMA_INST_MNK[2],  # 32
 )
 NUM_THREADS = (
@@ -74,7 +74,7 @@ def dynamic_mma_kernel(
     s2g_tiled_copy_o: cute.TiledCopy,
     sA_layout: cute.ComposedLayout,
     sB_layout: cute.ComposedLayout,
-    sC_layout: cute.Layout,
+    sC_layout: cute.ComposedLayout,
     sO_layout: cute.ComposedLayout,
     out_dtype: cutlass.Constexpr,
     is_gemm: cutlass.Constexpr[bool],
@@ -460,7 +460,14 @@ def dynamic_mma_gemm(
     )
     sA_layout = cute.tile_to_shape(atom_AB, (BLK_M, BLK_K), order=(0, 1))
     sB_layout = cute.tile_to_shape(atom_AB, (BLK_N, BLK_K), order=(0, 1))
-    sC_layout = cute.make_layout((BLK_M, BLK_N), stride=(BLK_N, 1))
+    # sC mirrors dynamic_mma.cu's SmemLayoutC: Swizzle<3,3,3> o (8 x min(64, BLK_N)).
+    inner_C = min(64, BLK_N)
+    atom_C = cute.make_composed_layout(
+        swz,
+        0,
+        cute.make_layout((8, inner_C), stride=(inner_C, 1)),
+    )
+    sC_layout = cute.tile_to_shape(atom_C, (BLK_M, BLK_N), order=(0, 1))
     # sO mirrors dynamic_mma.cu's SmemLayoutO: Swizzle<3,3,3> o (8 x min(64, BLK_N)).
     inner_O = min(64, BLK_N)
     atom_O = cute.make_composed_layout(
@@ -500,13 +507,19 @@ def dynamic_mma_gemm(
     g2s_tiled_copy_c = cute.make_tiled_copy_tv(g2s_atom_c, tlC_thr, tlC_val)
 
     # ----- R2S + S2G copies for the smem-staged epilogue -----
-    # R2S: MMA-derived TiledCopy so the per-thread register fragment
-    # lands at its natural smem position. Universal-copy lowering is
-    # used here (DSL exposes ``StMatrix8x8x16bOp`` for SM90, but a
-    # universal copy keeps the kernel portable across older arches and
-    # was sufficient for our correctness target).
+    # R2S: MMA-derived TiledCopy so the per-thread register fragment lands
+    # at its natural smem position under the swizzled sO layout. Pick the
+    # op the same way dynamic_mma.cu does: SM90+ with a 16-bit output uses
+    # ``stmatrix`` (x2 because the C/O fragment has no K val-expand and so
+    # owns 2 32-bit packets per thread); otherwise fall back to a universal
+    # STS lowering.
     universal = cute.nvgpu.CopyUniversalOp()
-    r2s_atom_o = cute.make_copy_atom(universal, mO.element_type)
+    sm_major, _ = torch.cuda.get_device_capability()
+    if cutlass.const_expr(sm_major >= 9 and mO.element_type.width == 16):
+        stm_op = cute.nvgpu.warp.StMatrix8x8x16bOp(False, 2)
+        r2s_atom_o = cute.make_copy_atom(stm_op, mO.element_type)
+    else:
+        r2s_atom_o = cute.make_copy_atom(universal, mO.element_type)
     r2s_tiled_copy_o = cute.make_tiled_copy_C(r2s_atom_o, tm)
 
     # S2G: explicit TV layout matching dynamic_mma.cu's TiledCopyO_S2G —

--- a/08-dynamic-mma/dynamic_mma.cu
+++ b/08-dynamic-mma/dynamic_mma.cu
@@ -339,7 +339,7 @@ struct KernelSpec {
   static constexpr int kMmaThrExpandK = 1;
 
   static constexpr int kMmaValExpandM = 1;
-  static constexpr int kMmaValExpandN = 2;
+  static constexpr int kMmaValExpandN = 1;
   static constexpr int kMmaValExpandK = 2;
 
   static constexpr int kMmaTileM = kMmaThrExpandM * kMmaValExpandM * get<0>(MMA_shape{});
@@ -362,7 +362,11 @@ struct KernelSpec {
   // Note: ldmatrix only support 16-bit data type (or below)
   using Copy_S2R_op_A = std::conditional_t<sizeof(ComputeTypeA) == 2, SM75_U32x4_LDSM_N, AutoVectorizingCopy>;
   using Copy_S2R_op_B = std::conditional_t<sizeof(ComputeTypeB) == 2, SM75_U32x4_LDSM_N, AutoVectorizingCopy>;
-  using Copy_S2R_op_C = std::conditional_t<sizeof(ComputeTypeC) == 2, SM75_U32x4_LDSM_N, AutoVectorizingCopy>;
+  // The C / O accumulator fragment has no K val-expand, so each thread only
+  // owns half the 32-bit packets of an A/B fragment. Use the x2 LDSM/STSM
+  // variant for C-side copies; A/B keep x4 because VAL_EXPAND_K=2 gives them
+  // enough vals/thread.
+  using Copy_S2R_op_C = std::conditional_t<sizeof(ComputeTypeC) == 2, SM75_U32x2_LDSM_N, AutoVectorizingCopy>;
 
   using CopyA_G2S_atom = Copy_Atom<Copy_G2S_op, ComputeTypeA>;
   using CopyB_G2S_atom = Copy_Atom<Copy_G2S_op, ComputeTypeB>;
@@ -373,7 +377,9 @@ struct KernelSpec {
   using CopyC_S2R_atom = Copy_Atom<Copy_S2R_op_C, ComputeTypeC>;
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-  using Copy_R2S_op = SM90_U32x4_STSM_N;
+  // R2S writes a C-shaped fragment, so match the C-side x2 variant chosen
+  // above. SM90_U32x4_STSM_N would static_assert on too-few vals/thread.
+  using Copy_R2S_op = SM90_U32x2_STSM_N;
 #else
   using Copy_R2S_op = AutoVectorizingCopy;
 #endif

--- a/09-pipelining/cutedsl_pipelining.py
+++ b/09-pipelining/cutedsl_pipelining.py
@@ -59,10 +59,10 @@ NUM_STAGES = 3
 
 MMA_INST_MNK = (16, 8, 16)
 ATOM_LAYOUT_MNK = (2, 4, 1)
-VAL_EXPAND_MNK = (1, 2, 2)
+VAL_EXPAND_MNK = (1, 1, 2)
 MMA_TILE_MNK = (
     ATOM_LAYOUT_MNK[0] * VAL_EXPAND_MNK[0] * MMA_INST_MNK[0],  # 32
-    ATOM_LAYOUT_MNK[1] * VAL_EXPAND_MNK[1] * MMA_INST_MNK[1],  # 64
+    ATOM_LAYOUT_MNK[1] * VAL_EXPAND_MNK[1] * MMA_INST_MNK[1],  # 32
     ATOM_LAYOUT_MNK[2] * VAL_EXPAND_MNK[2] * MMA_INST_MNK[2],  # 32
 )
 NUM_THREADS = (
@@ -92,7 +92,7 @@ def pipelining_kernel(
     s2g_tiled_copy_o: cute.TiledCopy,
     sA_layout: cute.ComposedLayout,
     sB_layout: cute.ComposedLayout,
-    sC_layout: cute.Layout,
+    sC_layout: cute.ComposedLayout,
     sO_layout: cute.ComposedLayout,
     out_dtype: cutlass.Constexpr,
     is_gemm: cutlass.Constexpr[bool],
@@ -529,7 +529,14 @@ def pipelining_gemm(
         (BLK_N, BLK_K, NUM_STAGES),
         order=(0, 1, 2),
     )
-    sC_layout = cute.make_layout((BLK_M, BLK_N), stride=(BLK_N, 1))
+    # sC mirrors pipelining.cu's SmemLayoutC: Swizzle<3,3,3> o (8 x min(64, BLK_N)).
+    inner_C = min(64, BLK_N)
+    atom_C = cute.make_composed_layout(
+        swz,
+        0,
+        cute.make_layout((8, inner_C), stride=(inner_C, 1)),
+    )
+    sC_layout = cute.tile_to_shape(atom_C, (BLK_M, BLK_N), order=(0, 1))
     # sO mirrors pipelining.cu's SmemLayoutO: Swizzle<3,3,3> o (8 x min(64, BLK_N)).
     # Single-stage — the epilogue runs after the mainloop finishes draining,
     # so no PIPE mode is needed.
@@ -577,9 +584,18 @@ def pipelining_gemm(
     s2r_tiled_copy_c = cute.make_tiled_copy_C(s2r_atom_c, tm)
 
     # ----- R2S + S2G copies for the smem-staged epilogue -----
-    # R2S: MMA-derived TiledCopy so each thread's accumulator fragment
-    # lands at its natural smem position under the swizzled sO layout.
-    r2s_atom_o = cute.make_copy_atom(universal, mO.element_type)
+    # R2S: MMA-derived TiledCopy so each thread's accumulator fragment lands
+    # at its natural smem position under the swizzled sO layout. Pick the op
+    # the same way pipelining.cu does: SM90+ with a 16-bit output uses
+    # ``stmatrix`` (x2 because the C/O fragment has no K val-expand and so
+    # owns 2 32-bit packets per thread); otherwise fall back to a universal
+    # STS lowering.
+    sm_major, _ = torch.cuda.get_device_capability()
+    if cutlass.const_expr(sm_major >= 9 and mO.element_type.width == 16):
+        stm_op = cute.nvgpu.warp.StMatrix8x8x16bOp(False, 2)
+        r2s_atom_o = cute.make_copy_atom(stm_op, mO.element_type)
+    else:
+        r2s_atom_o = cute.make_copy_atom(universal, mO.element_type)
     r2s_tiled_copy_o = cute.make_tiled_copy_C(r2s_atom_o, tm)
 
     # S2G: explicit TV layout — threads packed contiguously along N,

--- a/09-pipelining/pipelining.cu
+++ b/09-pipelining/pipelining.cu
@@ -390,7 +390,7 @@ struct KernelSpec {
   static constexpr int kMmaThrExpandK = 1;
 
   static constexpr int kMmaValExpandM = 1;
-  static constexpr int kMmaValExpandN = 2;
+  static constexpr int kMmaValExpandN = 1;
   static constexpr int kMmaValExpandK = 2;
 
   static constexpr int kMmaTileM = kMmaThrExpandM * kMmaValExpandM * get<0>(MMA_shape{});
@@ -407,7 +407,11 @@ struct KernelSpec {
 
   using Copy_S2R_op_A = std::conditional_t<sizeof(ComputeTypeA) == 2, SM75_U32x4_LDSM_N, AutoVectorizingCopy>;
   using Copy_S2R_op_B = std::conditional_t<sizeof(ComputeTypeB) == 2, SM75_U32x4_LDSM_N, AutoVectorizingCopy>;
-  using Copy_S2R_op_C = std::conditional_t<sizeof(ComputeTypeC) == 2, SM75_U32x4_LDSM_N, AutoVectorizingCopy>;
+  // The C / O accumulator fragment has no K val-expand, so each thread only
+  // owns half the 32-bit packets of an A/B fragment. Use the x2 LDSM/STSM
+  // variant for C-side copies; A/B keep x4 because VAL_EXPAND_K=2 gives them
+  // enough vals/thread.
+  using Copy_S2R_op_C = std::conditional_t<sizeof(ComputeTypeC) == 2, SM75_U32x2_LDSM_N, AutoVectorizingCopy>;
 
   using CopyA_G2S_atom = Copy_Atom<Copy_G2S_op, ComputeTypeA>;
   using CopyB_G2S_atom = Copy_Atom<Copy_G2S_op, ComputeTypeB>;
@@ -418,7 +422,9 @@ struct KernelSpec {
   using CopyC_S2R_atom = Copy_Atom<Copy_S2R_op_C, ComputeTypeC>;
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-  using Copy_R2S_op = SM90_U32x4_STSM_N;
+  // R2S writes a C-shaped fragment, so match the C-side x2 variant chosen
+  // above. SM90_U32x4_STSM_N would static_assert on too-few vals/thread.
+  using Copy_R2S_op = SM90_U32x2_STSM_N;
 #else
   using Copy_R2S_op = AutoVectorizingCopy;
 #endif

--- a/09-pipelining/pipelining_no_reg_prefetch.cu
+++ b/09-pipelining/pipelining_no_reg_prefetch.cu
@@ -371,7 +371,7 @@ struct KernelSpec {
   static constexpr int kMmaThrExpandK = 1;
 
   static constexpr int kMmaValExpandM = 1;
-  static constexpr int kMmaValExpandN = 2;
+  static constexpr int kMmaValExpandN = 1;
   static constexpr int kMmaValExpandK = 2;
 
   static constexpr int kMmaTileM = kMmaThrExpandM * kMmaValExpandM * get<0>(MMA_shape{});
@@ -388,7 +388,11 @@ struct KernelSpec {
 
   using Copy_S2R_op_A = std::conditional_t<sizeof(ComputeTypeA) == 2, SM75_U32x4_LDSM_N, AutoVectorizingCopy>;
   using Copy_S2R_op_B = std::conditional_t<sizeof(ComputeTypeB) == 2, SM75_U32x4_LDSM_N, AutoVectorizingCopy>;
-  using Copy_S2R_op_C = std::conditional_t<sizeof(ComputeTypeC) == 2, SM75_U32x4_LDSM_N, AutoVectorizingCopy>;
+  // The C / O accumulator fragment has no K val-expand, so each thread only
+  // owns half the 32-bit packets of an A/B fragment. Use the x2 LDSM/STSM
+  // variant for C-side copies; A/B keep x4 because VAL_EXPAND_K=2 gives them
+  // enough vals/thread.
+  using Copy_S2R_op_C = std::conditional_t<sizeof(ComputeTypeC) == 2, SM75_U32x2_LDSM_N, AutoVectorizingCopy>;
 
   using CopyA_G2S_atom = Copy_Atom<Copy_G2S_op, ComputeTypeA>;
   using CopyB_G2S_atom = Copy_Atom<Copy_G2S_op, ComputeTypeB>;
@@ -399,7 +403,9 @@ struct KernelSpec {
   using CopyC_S2R_atom = Copy_Atom<Copy_S2R_op_C, ComputeTypeC>;
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-  using Copy_R2S_op = SM90_U32x4_STSM_N;
+  // R2S writes a C-shaped fragment, so match the C-side x2 variant chosen
+  // above. SM90_U32x4_STSM_N would static_assert on too-few vals/thread.
+  using Copy_R2S_op = SM90_U32x2_STSM_N;
 #else
   using Copy_R2S_op = AutoVectorizingCopy;
 #endif


### PR DESCRIPTION
## Summary

Unify 07/08/09 MMA tile to match 05/06's `ATOM_LAYOUT_MNK=(2,4,1)` / `VAL_EXPAND_MNK=(1,1,2)` (32x32x32 MMA tile, 256 threads), and bring the cutedsl ports closer to their C++ siblings.

- **C++ (07/08/09)**: downgrade C-side `SM75_U32x4_LDSM_N` -> `SM75_U32x2_LDSM_N` and SM90 `STSM_N` x4 -> x2. The C/O fragment has no K val-expand, so each thread owns 2 32-bit packets, and the x4 variant fails its `static_assert`; A/B keep x4 because `VAL_EXPAND_K=2` gives them enough vals/thread.
- **cutedsl (07/08/09)**: arch-gated R2S - SM90 + 16-bit output uses `StMatrix8x8x16bOp(False, 2)`, else `CopyUniversalOp`, mirroring the C++ SM90 STSM branch. Predicate wrapped in `cutlass.const_expr` so the trace picks one branch statically.
- **cutedsl (07/08/09)**: add swizzled `sC` layout (`Swizzle<3,3,3> o (8 x min(64, N))`) to mirror C++ `SmemLayoutC`. 07 also pulls `partition_S/D` into named tensors before `cute.copy` to match the C++ style.
- **cutedsl (06)**: refactor G2S TV layouts from hardcoded `(32,8)/(1,8)` and `(1,4)` to the parametric `block_k_copy = min(64,K)//(16//elt_bytes)` + `val=(1, 16//elt_bytes)` formula used by 07-09, matching the C++ `kBlockK_Copy` / `kBlockN_Copy` template.
